### PR TITLE
prevent img swap on disable

### DIFF
--- a/src/enlarge.js
+++ b/src/enlarge.js
@@ -173,6 +173,12 @@
  							targetImg.src = imgOriginalSrc;
  						}
  					} else {
+						// if the zooming is disabled do not replace with the larger source
+						// NOTE we don't prevent switching to the original source because we
+						// always want to allow the plugin to back out of the zoomed state
+						// when disabled
+						if( o.disabled ) { return false; }
+
  						var zoomimg = new Image();
  						zoomimg.className = "enlarge_img-loading";
  						$( zoomimg ).insertBefore( targetImg );


### PR DESCRIPTION
Addresses https://github.com/filamentgroup/akamai-viewer/issues/288

Toggling the image source to a larger image should be disabled when the component is disabled.